### PR TITLE
Set quote currency minimum

### DIFF
--- a/src/ico/models.py
+++ b/src/ico/models.py
@@ -353,14 +353,21 @@ class PurchaseManager(models.Manager):
                 created__gte=date_from).latest('created')
 
         except Quote.DoesNotExist:
-            rate = Rate.objects.get(phase=phase, currency=deposit_currency)
-            token_amount = Decimal(deposit_amount / rate.rate)
-            quote = Quote.objects.create(user=user, 
-                                         phase=phase,
-                                         deposit_amount=deposit_amount, 
-                                         deposit_currency=deposit_currency,
-                                         token_amount=token_amount,
-                                         rate=rate.rate)
+            # Stop a new quote from being created if the deposit amount is
+            # lower than the minimum allowed amount for the deposit currency
+            # Silently fail the purchase so that Rehive does not keep retrying
+            if deposit_amount < from_cents(1, deposit_divisibility):
+                raise SilentException
+            else:
+                rate = Rate.objects.get(phase=phase, currency=deposit_currency)
+                token_amount = Decimal(deposit_amount / rate.rate)
+                quote = Quote.objects.create(
+                    user=user,
+                    phase=phase,
+                    deposit_amount=deposit_amount, 
+                    deposit_currency=deposit_currency,
+                    token_amount=token_amount,
+                    rate=rate.rate)
 
         return self.create_purchase(quote, tx_id, status, metadata)
 

--- a/src/ico/models.py
+++ b/src/ico/models.py
@@ -357,6 +357,12 @@ class PurchaseManager(models.Manager):
             # lower than the minimum allowed amount for the deposit currency
             # Silently fail the purchase so that Rehive does not keep retrying
             if deposit_amount < from_cents(1, deposit_divisibility):
+                logger.exception(
+                    'Deposit amount is below the min amount '
+                    'of {currency} {deposit_amount}.'.format(
+                        deposit_amount=from_cents(1, deposit_divisibility),
+                        currency=deposit_currency
+                    ))
                 raise SilentException
             else:
                 rate = Rate.objects.get(phase=phase, currency=deposit_currency)

--- a/src/ico/serializers.py
+++ b/src/ico/serializers.py
@@ -730,7 +730,7 @@ class UserCreateQuoteSerializer(serializers.ModelSerializer):
 
         if deposit_amount < from_cents(1, deposit_currency.divisibility):
             raise serializers.ValidationError(
-                {'non_field_errors': [
+                {'deposit_amount': [
                     'Deposit amount is below the min amount '
                     'of {currency} {deposit_amount}.'
                     .format(

--- a/src/ico/serializers.py
+++ b/src/ico/serializers.py
@@ -728,6 +728,16 @@ class UserCreateQuoteSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError(
                 {"token_amount": ["Amount is below the min purchase amount."]})
 
+        if deposit_amount < from_cents(1, deposit_currency.divisibility):
+            raise serializers.ValidationError(
+                {'non_field_errors': [
+                    'Deposit amount is below the min amount '
+                    'of {currency} {deposit_amount}.'
+                    .format(
+                        deposit_amount=from_cents(1, deposit_currency.divisibility),
+                        currency=deposit_currency
+                    )]})
+
         create_data = {
             "user": user,
             "phase": phase,


### PR DESCRIPTION
The serializer checks if the deposit amount for the currency is higher than the logical minimum for that currency. This is also checked in the model although, in theory, this should not happen because from Rehive the minimum amount that can be sent is 1 (in cents, which is the minimum logical value for a currency). I added it anyway since I am not sure whether this is the case with other services that interact with the ico service.

let me know if I missed any checks